### PR TITLE
Add the ability to set the maximum number of allowed violations before a build fails

### DIFF
--- a/src/main/java/org/apache/maven/plugins/pmd/AbstractPmdViolationCheckMojo.java
+++ b/src/main/java/org/apache/maven/plugins/pmd/AbstractPmdViolationCheckMojo.java
@@ -87,6 +87,14 @@ public abstract class AbstractPmdViolationCheckMojo<D>
     @Parameter( property = "pmd.excludeFromFailureFile", defaultValue = "" )
     private String excludeFromFailureFile;
 
+    /**
+     * The maximum number of violations allowed before execution fails.
+     *
+     * @since 3.10
+     */
+    @Parameter( property = "pmd.maxAllowedViolations", defaultValue = "0" )
+    private int maxAllowedViolations;
+
     /** Helper to exclude violations from the result. */
     private final ExcludeFromFile<D> excludeFromFile;
 
@@ -143,7 +151,7 @@ public abstract class AbstractPmdViolationCheckMojo<D>
 
                 getLog().debug( "PMD failureCount: " + failureCount + ", warningCount: " + warningCount );
 
-                if ( failureCount > 0 && isFailOnViolation() )
+                if ( failureCount > getMaxAllowedViolations() && isFailOnViolation() )
                 {
                     throw new MojoFailureException( message );
                 }
@@ -294,5 +302,10 @@ public abstract class AbstractPmdViolationCheckMojo<D>
     public boolean isFailOnViolation()
     {
         return failOnViolation;
+    }
+
+    public Integer getMaxAllowedViolations()
+    {
+        return maxAllowedViolations;
     }
 }

--- a/src/main/java/org/apache/maven/plugins/pmd/AbstractPmdViolationCheckMojo.java
+++ b/src/main/java/org/apache/maven/plugins/pmd/AbstractPmdViolationCheckMojo.java
@@ -90,7 +90,7 @@ public abstract class AbstractPmdViolationCheckMojo<D>
     /**
      * The maximum number of violations allowed before execution fails.
      *
-     * @since 3.10
+     * @since 3.10.0
      */
     @Parameter( property = "pmd.maxAllowedViolations", defaultValue = "0" )
     private int maxAllowedViolations;

--- a/src/test/java/org/apache/maven/plugins/pmd/PmdViolationCheckMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/pmd/PmdViolationCheckMojoTest.java
@@ -78,6 +78,48 @@ public class PmdViolationCheckMojoTest
         assertTrue( true );
     }
 
+    public void testMaxAllowedViolations()
+        throws Exception
+    {
+        File testPom =
+            new File( getBasedir(),
+                "src/test/resources/unit/default-configuration/default-configuration-plugin-config.xml" );
+        final PmdReport mojo = (PmdReport) lookupMojo( "pmd", testPom );
+        mojo.execute();
+
+        testPom =
+            new File( getBasedir(),
+                "src/test/resources/unit/default-configuration/pmd-check-notfailmaxviolation-plugin-config.xml" );
+        final PmdViolationCheckMojo pmdViolationMojo = (PmdViolationCheckMojo) lookupMojo( "check", testPom );
+        pmdViolationMojo.execute();
+
+        testPom =
+            new File( getBasedir(),
+                "src/test/resources/unit/default-configuration/pmd-check-failmaxviolation-plugin-config.xml" );
+        final PmdViolationCheckMojo pmdViolationMojoFail = (PmdViolationCheckMojo) lookupMojo( "check", testPom );
+
+        try
+        {
+            pmdViolationMojoFail.execute();
+            fail( "Exception Expected" );
+        }
+        catch ( final MojoFailureException e )
+        {
+            String message = e.getMessage();
+            if ( message.contains( "You have 5 PMD violations and 3 warnings." ) )
+            {
+                System.out.println( "Caught expected message: " + e.getMessage() );// expected
+            }
+            else
+            {
+                throw new AssertionError( "Expected: '" + message
+                    + "' to contain 'You have 5 PMD violations and 3 warnings.'" );
+            }
+        }
+
+        assertTrue( true );
+    }
+
     public void testFailurePriority()
         throws Exception
     {

--- a/src/test/java/org/apache/maven/plugins/pmd/PmdViolationCheckMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/pmd/PmdViolationCheckMojoTest.java
@@ -117,7 +117,6 @@ public class PmdViolationCheckMojoTest
             }
         }
 
-        assertTrue( true );
     }
 
     public void testFailurePriority()

--- a/src/test/resources/unit/default-configuration/pmd-check-failmaxviolation-plugin-config.xml
+++ b/src/test/resources/unit/default-configuration/pmd-check-failmaxviolation-plugin-config.xml
@@ -1,0 +1,54 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>custom.configuration</groupId>
+    <artifactId>custom-configuration</artifactId>
+    <packaging>jar</packaging>
+    <version>1.0-SNAPSHOT</version>
+    <inceptionYear>2006</inceptionYear>
+    <name>Maven PMD Violation Check Custom Configuration Test</name>
+    <url>http://maven.apache.org</url>
+    <build>
+        <finalName>custom-configuration</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-pmd-plugin</artifactId>
+                <configuration>
+                    <project implementation="org.apache.maven.plugins.pmd.stubs.DefaultConfigurationMavenProjectStub"/>
+                    <targetDirectory>${basedir}/target/test/unit/default-configuration/target</targetDirectory>
+                    <failOnViolation>true</failOnViolation>
+                    <failurePriority>3</failurePriority>
+                    <verbose>true</verbose>
+                    <maxAllowedViolations>3</maxAllowedViolations>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <reporting>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jxr-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </reporting>
+</project>

--- a/src/test/resources/unit/default-configuration/pmd-check-notfailmaxviolation-plugin-config.xml
+++ b/src/test/resources/unit/default-configuration/pmd-check-notfailmaxviolation-plugin-config.xml
@@ -1,0 +1,54 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>custom.configuration</groupId>
+    <artifactId>custom-configuration</artifactId>
+    <packaging>jar</packaging>
+    <version>1.0-SNAPSHOT</version>
+    <inceptionYear>2006</inceptionYear>
+    <name>Maven PMD Violation Check Custom Configuration Test</name>
+    <url>http://maven.apache.org</url>
+    <build>
+        <finalName>custom-configuration</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-pmd-plugin</artifactId>
+                <configuration>
+                    <project implementation="org.apache.maven.plugins.pmd.stubs.DefaultConfigurationMavenProjectStub"/>
+                    <targetDirectory>${basedir}/target/test/unit/default-configuration/target</targetDirectory>
+                    <failOnViolation>true</failOnViolation>
+                    <failurePriority>3</failurePriority>
+                    <verbose>true</verbose>
+                    <maxAllowedViolations>5</maxAllowedViolations>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <reporting>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jxr-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </reporting>
+</project>


### PR DESCRIPTION
Add the option to allow users to set the maximum number of violations that can occur before a build fails.