### PR TITLE
MPMD-288 Fixed NullPointerException

### DIFF
--- a/src/main/java/org/apache/maven/plugins/pmd/PmdReport.java
+++ b/src/main/java/org/apache/maven/plugins/pmd/PmdReport.java
@@ -769,7 +769,7 @@ public class PmdReport
                         for ( String path : projectCompileClasspath )
                         {
                             File pathFile = new File( path );
-                            if ( !pathFile.exists() || pathFile.list().length == 0 )
+                            if ( !pathFile.exists() || pathFile.list() == null || pathFile.list().length == 0 )
                             {
                                 getLog().warn( "The project " + localProject.getArtifactId()
                                     + " does not seem to be compiled. PMD results might be inaccurate." );

--- a/src/main/java/org/apache/maven/plugins/pmd/PmdReport.java
+++ b/src/main/java/org/apache/maven/plugins/pmd/PmdReport.java
@@ -769,7 +769,9 @@ public class PmdReport
                         for ( String path : projectCompileClasspath )
                         {
                             File pathFile = new File( path );
-                            if ( !pathFile.exists() || pathFile.list() == null || pathFile.list().length == 0 )
+                            String[] children = pathFile.list();
+                            
+                            if ( !pathFile.exists() || children == null || children.length == 0 )
                             {
                                 getLog().warn( "The project " + localProject.getArtifactId()
                                     + " does not seem to be compiled. PMD results might be inaccurate." );


### PR DESCRIPTION
this line throws NullPointerException when `File.list()` returns `null`

[See related javadoc](https://docs.oracle.com/javase/8/docs/api/java/io/File.html#list--)

For me this occurs on jar files like `~/.m2/repository/org/apache/logging/log4j/log4j-api/2.11.1/log4j-api-2.11.1.jar`