### PR TITLE
Make maven core provided scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,7 @@ under the License.
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-core</artifactId>
       <version>${mavenVersion}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>


### PR DESCRIPTION
Maven core artifacts should be in provided scope.  While bumped to 3.1.1 in master, maven-pmd-plugin 3.15.0 leaks old asm due to incorrect scope while stating in pom exclusion elsewhere for same leak concern (on maven-embedder).  I believe there are more that should be set to provided but kept this as small as possible to match when it was applied in release 3.15.0.  The original diff shows where issue was introduced [here](https://github.com/apache/maven-pmd-plugin/commit/3ffd4d3762028b1b0a8f714297a21de37d0c5649) in that maven-core was raised up to 3.1.0 and had asm issue at that point.

note: maven-core 3.1.1 does not expose asm issue, just clarifying current release has this issue due to 3.1.0.