### PR TITLE
Remove vestigial useJava5 parameter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -349,7 +349,6 @@ under the License.
         <groupId>org.codehaus.modello</groupId>
         <artifactId>modello-maven-plugin</artifactId>
         <configuration>
-          <useJava5>true</useJava5>
           <models>
             <model>src/main/mdo/pmd.mdo</model>
             <model>src/main/mdo/cpd.mdo</model>


### PR DESCRIPTION
There are warnings in the build about this. 