### PR TITLE
[MPMD-369] Make integration tests robust against system encoding

### DIFF
--- a/src/main/java/org/apache/maven/plugins/pmd/CpdViolationCheckMojo.java
+++ b/src/main/java/org/apache/maven/plugins/pmd/CpdViolationCheckMojo.java
@@ -115,10 +115,12 @@ public class CpdViolationCheckMojo
      * {@inheritDoc}
      */
     @Override
-    protected List<Duplication> getErrorDetails(File cpdFile) throws XmlPullParserException, IOException {
-        try (InputStream in = new FileInputStream(cpdFile)) {
+    protected List<Duplication> getErrorDetails( File cpdFile ) throws XmlPullParserException, IOException
+    {
+        try ( InputStream in = new FileInputStream( cpdFile ) )
+        {
             CpdXpp3Reader reader = new CpdXpp3Reader();
-            CpdErrorDetail details = reader.read(in, false);
+            CpdErrorDetail details = reader.read( in, false );
             return details.getDuplications();
         }
     }

--- a/src/main/java/org/apache/maven/plugins/pmd/CpdViolationCheckMojo.java
+++ b/src/main/java/org/apache/maven/plugins/pmd/CpdViolationCheckMojo.java
@@ -20,8 +20,9 @@ package org.apache.maven.plugins.pmd;
  */
 
 import java.io.File;
-import java.io.FileReader;
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.List;
 
 import org.apache.maven.plugin.MojoExecutionException;
@@ -114,13 +115,10 @@ public class CpdViolationCheckMojo
      * {@inheritDoc}
      */
     @Override
-    protected List<Duplication> getErrorDetails( File cpdFile )
-        throws XmlPullParserException, IOException
-    {
-        try ( FileReader fileReader = new FileReader( cpdFile ) )
-        {
+    protected List<Duplication> getErrorDetails(File cpdFile) throws XmlPullParserException, IOException {
+        try (InputStream in = new FileInputStream(cpdFile)) {
             CpdXpp3Reader reader = new CpdXpp3Reader();
-            CpdErrorDetail details = reader.read( fileReader, false );
+            CpdErrorDetail details = reader.read(in, false);
             return details.getDuplications();
         }
     }

--- a/src/main/java/org/apache/maven/plugins/pmd/PmdViolationCheckMojo.java
+++ b/src/main/java/org/apache/maven/plugins/pmd/PmdViolationCheckMojo.java
@@ -125,10 +125,12 @@ public class PmdViolationCheckMojo
     }
 
     @Override
-    protected List<Violation> getErrorDetails(File pmdFile) throws XmlPullParserException, IOException {
-        try (InputStream in = new FileInputStream(pmdFile)) {
+    protected List<Violation> getErrorDetails( File pmdFile ) throws XmlPullParserException, IOException
+    {
+        try ( InputStream in = new FileInputStream( pmdFile ) )
+        {
             PmdXpp3Reader reader = new PmdXpp3Reader();
-            PmdErrorDetail details = reader.read(in, false);
+            PmdErrorDetail details = reader.read( in, false );
             List<Violation> violations = new ArrayList<>();
             for ( PmdFile file : details.getFiles() )
             {

--- a/src/main/java/org/apache/maven/plugins/pmd/PmdViolationCheckMojo.java
+++ b/src/main/java/org/apache/maven/plugins/pmd/PmdViolationCheckMojo.java
@@ -20,8 +20,9 @@ package org.apache.maven.plugins.pmd;
  */
 
 import java.io.File;
-import java.io.FileReader;
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -124,14 +125,10 @@ public class PmdViolationCheckMojo
     }
 
     @Override
-    protected List<Violation> getErrorDetails( File pmdFile )
-        throws XmlPullParserException, IOException
-    {
-        try ( FileReader reader1 = new FileReader( pmdFile ) )
-        {
+    protected List<Violation> getErrorDetails(File pmdFile) throws XmlPullParserException, IOException {
+        try (InputStream in = new FileInputStream(pmdFile)) {
             PmdXpp3Reader reader = new PmdXpp3Reader();
-            PmdErrorDetail details = reader.read( reader1, false );
-
+            PmdErrorDetail details = reader.read(in, false);
             List<Violation> violations = new ArrayList<>();
             for ( PmdFile file : details.getFiles() )
             {


### PR DESCRIPTION
There are more instances to be fixed but I think these two are the major offenders that break the integration tests.