### PR TITLE
[MNG-6829] Replace any StringUtils#isEmpty(String) and #isNotEmpty(String)

### DIFF
--- a/src/main/java/org/apache/maven/plugins/pmd/AbstractPmdReport.java
+++ b/src/main/java/org/apache/maven/plugins/pmd/AbstractPmdReport.java
@@ -275,7 +275,7 @@ public abstract class AbstractPmdReport extends AbstractMavenReport {
 
             String relativePath =
                     PathTool.getRelativePath(outputDirectory.getAbsolutePath(), xrefLoc.getAbsolutePath());
-            if (StringUtils.isEmpty(relativePath)) {
+            if (relativePath == null || relativePath.isEmpty()) {
                 relativePath = ".";
             }
             relativePath = relativePath + "/" + xrefLoc.getName();

--- a/src/main/java/org/apache/maven/plugins/pmd/ExcludeDuplicationsFromFile.java
+++ b/src/main/java/org/apache/maven/plugins/pmd/ExcludeDuplicationsFromFile.java
@@ -28,7 +28,6 @@ import java.util.Set;
 
 import net.sourceforge.pmd.cpd.Mark;
 import net.sourceforge.pmd.cpd.Match;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.pmd.model.CpdFile;
 import org.apache.maven.plugins.pmd.model.Duplication;
@@ -99,7 +98,7 @@ public class ExcludeDuplicationsFromFile implements ExcludeFromFile<Duplication>
 
     @Override
     public void loadExcludeFromFailuresData(final String excludeFromFailureFile) throws MojoExecutionException {
-        if (StringUtils.isEmpty(excludeFromFailureFile)) {
+        if (excludeFromFailureFile == null || excludeFromFailureFile.isEmpty()) {
             return;
         }
 

--- a/src/main/java/org/apache/maven/plugins/pmd/ExcludeViolationsFromFile.java
+++ b/src/main/java/org/apache/maven/plugins/pmd/ExcludeViolationsFromFile.java
@@ -29,7 +29,6 @@ import java.util.Properties;
 import java.util.Set;
 
 import net.sourceforge.pmd.RuleViolation;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.pmd.model.Violation;
 
@@ -45,7 +44,7 @@ public class ExcludeViolationsFromFile implements ExcludeFromFile<Violation> {
 
     @Override
     public void loadExcludeFromFailuresData(final String excludeFromFailureFile) throws MojoExecutionException {
-        if (StringUtils.isEmpty(excludeFromFailureFile)) {
+        if (excludeFromFailureFile == null || excludeFromFailureFile.isEmpty()) {
             return;
         }
 
@@ -107,9 +106,9 @@ public class ExcludeViolationsFromFile implements ExcludeFromFile<Violation> {
     private String extractClassName(String packageName, String className, String fullPath) {
         // for some reason, some violations don't contain the package name, so we have to guess the full class name
         // this looks like a bug in PMD - at least for UnusedImport rule.
-        if (StringUtils.isNotEmpty(packageName) && StringUtils.isNotEmpty(className)) {
+        if ((packageName != null && !packageName.isEmpty()) && (className != null && !className.isEmpty())) {
             return packageName + "." + className;
-        } else if (StringUtils.isNotEmpty(packageName)) {
+        } else if (packageName != null && !packageName.isEmpty()) {
             String fileName = fullPath;
             fileName = fileName.substring(fileName.lastIndexOf(File.separatorChar) + 1);
             fileName = fileName.substring(0, fileName.length() - 5);

--- a/src/main/java/org/apache/maven/plugins/pmd/ExcludeViolationsFromFile.java
+++ b/src/main/java/org/apache/maven/plugins/pmd/ExcludeViolationsFromFile.java
@@ -106,7 +106,7 @@ public class ExcludeViolationsFromFile implements ExcludeFromFile<Violation> {
     private String extractClassName(String packageName, String className, String fullPath) {
         // for some reason, some violations don't contain the package name, so we have to guess the full class name
         // this looks like a bug in PMD - at least for UnusedImport rule.
-        if ((packageName != null && !packageName.isEmpty()) && (className != null && !className.isEmpty())) {
+        if (packageName != null && !packageName.isEmpty() && className != null && !className.isEmpty()) {
             return packageName + "." + className;
         } else if (packageName != null && !packageName.isEmpty()) {
             String fileName = fullPath;

--- a/src/main/java/org/apache/maven/plugins/pmd/PmdViolationCheckMojo.java
+++ b/src/main/java/org/apache/maven/plugins/pmd/PmdViolationCheckMojo.java
@@ -35,7 +35,6 @@ import org.apache.maven.plugins.pmd.model.PmdErrorDetail;
 import org.apache.maven.plugins.pmd.model.PmdFile;
 import org.apache.maven.plugins.pmd.model.Violation;
 import org.apache.maven.plugins.pmd.model.io.xpp3.PmdXpp3Reader;
-import org.codehaus.plexus.util.StringUtils;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 
 /**
@@ -143,7 +142,7 @@ public class PmdViolationCheckMojo extends AbstractPmdViolationCheckMojo<Violati
     private String getFilename(String fullpath, String pkg) {
         int index = fullpath.lastIndexOf(File.separatorChar);
 
-        while (StringUtils.isNotEmpty(pkg)) {
+        while ((pkg != null && !pkg.isEmpty())) {
             index = fullpath.substring(0, index).lastIndexOf(File.separatorChar);
 
             int dot = pkg.indexOf('.');

--- a/src/main/java/org/apache/maven/plugins/pmd/PmdViolationCheckMojo.java
+++ b/src/main/java/org/apache/maven/plugins/pmd/PmdViolationCheckMojo.java
@@ -142,7 +142,7 @@ public class PmdViolationCheckMojo extends AbstractPmdViolationCheckMojo<Violati
     private String getFilename(String fullpath, String pkg) {
         int index = fullpath.lastIndexOf(File.separatorChar);
 
-        while ((pkg != null && !pkg.isEmpty())) {
+        while (pkg != null && !pkg.isEmpty()) {
             index = fullpath.substring(0, index).lastIndexOf(File.separatorChar);
 
             int dot = pkg.indexOf('.');


### PR DESCRIPTION
### [Replace any StringUtils#isEmpty(String) and #isNotEmpty(String)](https://public.moderne.io/recipes/org.openrewrite.java.migrate.apache.commons.lang.IsNotEmptyToJdk)

Followup from #120 for @elharo