### PR TITLE
[MPMD-371] Using two ruleset files with same name in different directories

### DIFF
--- a/src/it/MPMD-296-rulesetsTargetDirectory/verify.groovy
+++ b/src/it/MPMD-296-rulesetsTargetDirectory/verify.groovy
@@ -22,13 +22,13 @@ File buildLog = new File( basedir, 'build.log' )
 assert buildLog.exists()
 
 // default configuration
-File defaultRuleset = new File( basedir, 'target/pmd/rulesets/maven-pmd-plugin-default.xml' )
+File defaultRuleset = new File( basedir, 'target/pmd/rulesets/001-maven-pmd-plugin-default.xml' )
 assert defaultRuleset.exists()
 
 // backwards compatible configuration (profile customTargetOld)
-File customTargetOld = new File( basedir, 'target/maven-pmd-plugin-default.xml' )
+File customTargetOld = new File( basedir, 'target/001-maven-pmd-plugin-default.xml' )
 assert customTargetOld.exists()
 
 // custom configuration (profile customTarget)
-File customTarget = new File( basedir, 'target/pmd-custom/maven-pmd-plugin-default.xml' )
+File customTarget = new File( basedir, 'target/pmd-custom/001-maven-pmd-plugin-default.xml' )
 assert customTarget.exists()

--- a/src/it/MPMD-323-multi-module-basedir/verify.groovy
+++ b/src/it/MPMD-323-multi-module-basedir/verify.groovy
@@ -17,8 +17,8 @@
  * under the License.
  */
 
-String[] files = [ "module-a/target/pmd.xml", "module-a/target/pmd/rulesets/ruleset.xml",
-                   "module-b/target/pmd.xml", "module-b/target/pmd/rulesets/ruleset.xml" ]
+String[] files = [ "module-a/target/pmd.xml", "module-a/target/pmd/rulesets/001-ruleset.xml",
+                   "module-b/target/pmd.xml", "module-b/target/pmd/rulesets/001-ruleset.xml" ]
 
 files.each
 {

--- a/src/it/multi-module/verify.bsh
+++ b/src/it/multi-module/verify.bsh
@@ -59,14 +59,14 @@ for ( String path : paths )
 
 
 // check PMD rulesets target copy
-File rule = new File( basedir, "mod-1/target/pmd/rulesets/latin-1.xml" );
+File rule = new File( basedir, "mod-1/target/pmd/rulesets/002-latin-1.xml" );
 String nonascii = "-CHARS: \u00C4\u00D6\u00DC\u00E4\u00F6\u00FC\u00DF\u00BC\u00BD\u00BE\u00A4";
 String content = FileUtils.fileRead( rule, "ISO-8859-1" );
 if ( content.indexOf( nonascii ) < 0 )
 {
     throw new IOException( "non-ascii content corrupted in Latin1." );
 }
-rule = new File( basedir, "mod-1/target/pmd/rulesets/utf-8.xml" );
+rule = new File( basedir, "mod-1/target/pmd/rulesets/001-utf-8.xml" );
 content = FileUtils.fileRead( rule, "UTF-8" );
 if ( content.indexOf( nonascii ) < 0 )
 {

--- a/src/main/java/org/apache/maven/plugins/pmd/PmdReport.java
+++ b/src/main/java/org/apache/maven/plugins/pmd/PmdReport.java
@@ -385,7 +385,7 @@ public class PmdReport extends AbstractPmdReport {
                 String set = rulesets[idx];
                 getLog().debug("Preparing ruleset: " + set);
                 String rulesetFilename = determineRulesetFilename(set);
-                File ruleset = locator.getResourceAsFile(rulesetFilename, getLocationTemp(set));
+                File ruleset = locator.getResourceAsFile(rulesetFilename, getLocationTemp(set, idx + 1));
                 if (null == ruleset) {
                     throw new MavenReportException("Could not resolve " + set);
                 }
@@ -449,9 +449,10 @@ public class PmdReport extends AbstractPmdReport {
      * Convenience method to get the location of the specified file name.
      *
      * @param name the name of the file whose location is to be resolved
+     * @param position position in the list of rulesets (1-based)
      * @return a String that contains the absolute file name of the file
      */
-    protected String getLocationTemp(String name) {
+    protected String getLocationTemp(String name, int position) {
         String loc = name;
         if (loc.indexOf('/') != -1) {
             loc = loc.substring(loc.lastIndexOf('/') + 1);
@@ -466,9 +467,10 @@ public class PmdReport extends AbstractPmdReport {
         // replace all occurrences of the following characters: ? : & = %
         loc = loc.replaceAll("[\\?\\:\\&\\=\\%]", "_");
 
-        if (!loc.endsWith(".xml")) {
-            loc = loc + ".xml";
+        if (loc.endsWith(".xml")) {
+            loc = loc.substring(0, loc.length() - 4);
         }
+        loc = String.format("%03d-%s.xml", position, loc);
 
         getLog().debug("Before: " + name + " After: " + loc);
         return loc;

--- a/src/test/java/org/apache/maven/plugins/pmd/PmdReportTest.java
+++ b/src/test/java/org/apache/maven/plugins/pmd/PmdReportTest.java
@@ -67,7 +67,7 @@ public class PmdReportTest extends AbstractPmdReportTestCase {
         // check if the rulesets, that have been applied, have been copied
         generatedFile = new File(
                 getBasedir(),
-                "target/test/unit/default-configuration/target/pmd/rulesets/maven-pmd-plugin-default.xml");
+                "target/test/unit/default-configuration/target/pmd/rulesets/001-maven-pmd-plugin-default.xml");
         assertTrue(FileUtils.fileExists(generatedFile.getAbsolutePath()));
 
         // check if there's a link to the JXR files
@@ -159,16 +159,16 @@ public class PmdReportTest extends AbstractPmdReportTestCase {
         assertTrue(FileUtils.fileExists(generatedFile.getAbsolutePath()));
 
         // these are the rulesets, that have been applied...
-        generatedFile =
-                new File(getBasedir(), "target/test/unit/default-configuration/target/pmd/rulesets/bestpractices.xml");
+        generatedFile = new File(
+                getBasedir(), "target/test/unit/default-configuration/target/pmd/rulesets/001-bestpractices.xml");
         assertTrue(FileUtils.fileExists(generatedFile.getAbsolutePath()));
 
         generatedFile =
-                new File(getBasedir(), "target/test/unit/default-configuration/target/pmd/rulesets/codestyle.xml");
+                new File(getBasedir(), "target/test/unit/default-configuration/target/pmd/rulesets/002-codestyle.xml");
         assertTrue(FileUtils.fileExists(generatedFile.getAbsolutePath()));
 
         generatedFile =
-                new File(getBasedir(), "target/test/unit/default-configuration/target/pmd/rulesets/errorprone.xml");
+                new File(getBasedir(), "target/test/unit/default-configuration/target/pmd/rulesets/003-errorprone.xml");
         assertTrue(FileUtils.fileExists(generatedFile.getAbsolutePath()));
 
         String str = readFile(generatedReport);
@@ -231,20 +231,21 @@ public class PmdReportTest extends AbstractPmdReportTestCase {
         assertTrue(FileUtils.fileExists(generatedFile.getAbsolutePath()));
 
         // the resolved and extracted rulesets
-        generatedFile = new File(getBasedir(), "target/test/unit/default-configuration/target/pmd/rulesets/basic.xml");
+        generatedFile =
+                new File(getBasedir(), "target/test/unit/default-configuration/target/pmd/rulesets/001-basic.xml");
         assertTrue(FileUtils.fileExists(generatedFile.getAbsolutePath()));
 
         generatedFile =
-                new File(getBasedir(), "target/test/unit/default-configuration/target/pmd/rulesets/imports.xml");
+                new File(getBasedir(), "target/test/unit/default-configuration/target/pmd/rulesets/002-unusedcode.xml");
         assertTrue(FileUtils.fileExists(generatedFile.getAbsolutePath()));
 
         generatedFile =
-                new File(getBasedir(), "target/test/unit/default-configuration/target/pmd/rulesets/unusedcode.xml");
+                new File(getBasedir(), "target/test/unit/default-configuration/target/pmd/rulesets/003-imports.xml");
         assertTrue(FileUtils.fileExists(generatedFile.getAbsolutePath()));
 
         generatedFile = new File(
                 getBasedir(),
-                "target/test/unit/default-configuration/target/pmd/rulesets/export_format_pmd_language_java_name_Sonar_2520way.xml");
+                "target/test/unit/default-configuration/target/pmd/rulesets/004-export_format_pmd_language_java_name_Sonar_2520way.xml");
         assertTrue(FileUtils.fileExists(generatedFile.getAbsolutePath()));
 
         // check if there's a link to the JXR files
@@ -278,7 +279,9 @@ public class PmdReportTest extends AbstractPmdReportTestCase {
         File generatedFile = new File(getBasedir(), "target/test/unit/custom-configuration/target/pmd.csv");
         assertTrue(FileUtils.fileExists(generatedFile.getAbsolutePath()));
 
-        generatedFile = new File(getBasedir(), "target/test/unit/custom-configuration/target/pmd/rulesets/custom.xml");
+        // 001-maven-pmd-plugin-default.xml is also generated, so we get 002-custom.xml
+        generatedFile =
+                new File(getBasedir(), "target/test/unit/custom-configuration/target/pmd/rulesets/002-custom.xml");
         assertTrue(FileUtils.fileExists(generatedFile.getAbsolutePath()));
 
         // check if custom ruleset was applied
@@ -419,9 +422,10 @@ public class PmdReportTest extends AbstractPmdReportTestCase {
 
         assertEquals(
                 "locationTemp is not correctly encoding filename",
-                "export_format_pmd_language_java_name_some_2520name.xml",
+                "001-export_format_pmd_language_java_name_some_2520name.xml",
                 mojo.getLocationTemp(
-                        "http://nemo.sonarsource.org/sonar/profiles/export?format=pmd&language=java&name=some%2520name"));
+                        "http://nemo.sonarsource.org/sonar/profiles/export?format=pmd&language=java&name=some%2520name",
+                        1));
     }
 
     /**
@@ -485,23 +489,24 @@ public class PmdReportTest extends AbstractPmdReportTestCase {
         assertTrue(FileUtils.fileExists(generatedFile.getAbsolutePath()));
 
         // these are the rulesets, that have been applied...
-        generatedFile =
-                new File(getBasedir(), "target/test/unit/default-configuration/target/pmd/rulesets/bestpractices.xml");
+        generatedFile = new File(
+                getBasedir(), "target/test/unit/default-configuration/target/pmd/rulesets/001-bestpractices.xml");
         assertTrue(FileUtils.fileExists(generatedFile.getAbsolutePath()));
 
         generatedFile =
-                new File(getBasedir(), "target/test/unit/default-configuration/target/pmd/rulesets/codestyle.xml");
-        assertTrue(FileUtils.fileExists(generatedFile.getAbsolutePath()));
-
-        generatedFile = new File(getBasedir(), "target/test/unit/default-configuration/target/pmd/rulesets/design.xml");
+                new File(getBasedir(), "target/test/unit/default-configuration/target/pmd/rulesets/002-codestyle.xml");
         assertTrue(FileUtils.fileExists(generatedFile.getAbsolutePath()));
 
         generatedFile =
-                new File(getBasedir(), "target/test/unit/default-configuration/target/pmd/rulesets/errorprone.xml");
+                new File(getBasedir(), "target/test/unit/default-configuration/target/pmd/rulesets/003-design.xml");
         assertTrue(FileUtils.fileExists(generatedFile.getAbsolutePath()));
 
         generatedFile =
-                new File(getBasedir(), "target/test/unit/default-configuration/target/pmd/rulesets/security.xml");
+                new File(getBasedir(), "target/test/unit/default-configuration/target/pmd/rulesets/004-errorprone.xml");
+        assertTrue(FileUtils.fileExists(generatedFile.getAbsolutePath()));
+
+        generatedFile =
+                new File(getBasedir(), "target/test/unit/default-configuration/target/pmd/rulesets/005-security.xml");
         assertTrue(FileUtils.fileExists(generatedFile.getAbsolutePath()));
 
         String str = readFile(generatedReport);
@@ -659,30 +664,30 @@ public class PmdReportTest extends AbstractPmdReportTestCase {
         generateReport(mojo, testPom);
 
         // these are the rulesets, that have been copied to target/pmd/rulesets
-        File generatedFile =
-                new File(getBasedir(), "target/test/unit/default-configuration/target/pmd/rulesets/custom-rules.xml");
+        File generatedFile = new File(
+                getBasedir(), "target/test/unit/default-configuration/target/pmd/rulesets/001-custom-rules.xml");
         assertTrue(FileUtils.fileExists(generatedFile.getAbsolutePath()));
 
-        generatedFile =
-                new File(getBasedir(), "target/test/unit/default-configuration/target/pmd/rulesets/bestpractices.xml");
+        generatedFile = new File(
+                getBasedir(), "target/test/unit/default-configuration/target/pmd/rulesets/002-bestpractices.xml");
         assertTrue(FileUtils.fileExists(generatedFile.getAbsolutePath()));
 
-        generatedFile =
-                new File(getBasedir(), "target/test/unit/default-configuration/target/pmd/rulesets/java-design.xml");
+        generatedFile = new File(
+                getBasedir(), "target/test/unit/default-configuration/target/pmd/rulesets/003-java-design.xml");
         assertTrue(FileUtils.fileExists(generatedFile.getAbsolutePath()));
 
         generatedFile = new File(
                 getBasedir(),
-                "target/test/unit/default-configuration/target/pmd/rulesets/export_format_pmd_language_java_name_Sonar_2520way.xml");
+                "target/test/unit/default-configuration/target/pmd/rulesets/004-export_format_pmd_language_java_name_Sonar_2520way.xml");
         assertTrue(FileUtils.fileExists(generatedFile.getAbsolutePath()));
 
         generatedFile =
-                new File(getBasedir(), "target/test/unit/default-configuration/target/pmd/rulesets/my-ruleset.xml");
+                new File(getBasedir(), "target/test/unit/default-configuration/target/pmd/rulesets/005-my-ruleset.xml");
         assertTrue(FileUtils.fileExists(generatedFile.getAbsolutePath()));
 
         generatedFile = new File(
                 getBasedir(),
-                "target/test/unit/default-configuration/target/pmd/rulesets/InProgressRuleset.xml_at_refs_2Fheads_2Fmaster.xml");
+                "target/test/unit/default-configuration/target/pmd/rulesets/006-InProgressRuleset.xml_at_refs_2Fheads_2Fmaster.xml");
         assertTrue(FileUtils.fileExists(generatedFile.getAbsolutePath()));
 
         mockServer.stop();


### PR DESCRIPTION
https://issues.apache.org/jira/browse/MPMD-371

### Problem

In version 3.20.0 (without this patch), two PMD rulesets that have the same filename will overwrite each other when staged into the `${project.build.directory}/pmd/rulesets/` directory.

In the following example, the two distinct `pmd-ruleset.xml` files will both be copied as `${project.build.directory}/pmd/rulesets/pmd-ruleset.xml`, so the last copied will overwrite the first: only one of those files will be taken into account.

```xml
<plugin>
    <groupId>org.apache.maven.plugins</groupId>
    <artifactId>maven-pmd-plugin</artifactId>
    <version>${pmd-maven-plugin.version}</version>
    <configuration>
        <rulesets>
            <ruleset>${project.basedir}/pmd-ruleset.xml</ruleset>
            <ruleset>${project-root.basedir}/pmd-ruleset.xml</ruleset>
        </rulesets>
    </configuration>
</plugin>
```

### Proposed solution

This patch prefixes the target filename with a counter, based on the position in the ruleset element.

For example:

```xml
<rulesets>
    <ruleset>${project.basedir}/pmd-ruleset.xml</ruleset>
    <ruleset>${project.basedir}/otherfolder/other-pmd-ruleset.xml</ruleset>
    <ruleset>${project.basedir}/otherfolder/pmd-ruleset.xml</ruleset>
</rulesets>
```

This would create 3 files in `${project.build.directory}/pmd/rulesets/`:

* `001-pmd-ruleset.xml` (copy of `${project.basedir}/pmd-ruleset.xml`)
* `002-other-pmd-ruleset.xml` (copy of `${project.basedir}/otherfolder/other-pmd-ruleset.xml`)
* `003-pmd-ruleset.xml` (copy of `${project.basedir}/otherfolder/pmd-ruleset.xml`, now **not** overwriting the first one)


This only required changes a few lines in `PmdReport#getLocationTemp(...)` and `PmdReport.resolveRulesets(...)`.

The rest of the changes is just about adapting the expected locations in those tests . (The expected filename is dependent on the order specified in the POM's `<rulesets />` element.)

The number format is `%03d`, so we assume we'll have fewer than 1000 ruleset files. (This may help if ruleset ordering ever mattered. An alternative would be to remove zero-padding.)


---

Following this checklist to help us incorporate your
contribution quickly and easily:

 - [X] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MPMD) filed
       for the change (usually before you start working on it).  Trivial changes like typos do not
       require a JIRA issue.  Your pull request should address just this issue, without
       pulling in other changes.
 - [X] Each commit in the pull request should have a meaningful subject line and body.
 - [X] Format the pull request title like `[MPMD-XXX] - Subject of the JIRA Ticket`,
       where you replace `MPMD-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the
       commit message.
 - [X] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [X] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will
       be performed on your pull request automatically.
 - [X] You have run the integration tests successfully (`mvn -Prun-its clean verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
