### PR TITLE
[MPMD-411] Implement getOutputPath and identify getOutputName as deprecated,

### DIFF
--- a/src/main/java/org/apache/maven/plugins/pmd/CpdReport.java
+++ b/src/main/java/org/apache/maven/plugins/pmd/CpdReport.java
@@ -210,7 +210,14 @@ public class CpdReport extends AbstractPmdReport {
     /**
      * {@inheritDoc}
      */
+    @Override
+    @Deprecated
     public String getOutputName() {
         return "cpd";
+    }
+
+    @Override
+    public String getOutputPath() {
+        return "pmd";
     }
 }

--- a/src/main/java/org/apache/maven/plugins/pmd/CpdReport.java
+++ b/src/main/java/org/apache/maven/plugins/pmd/CpdReport.java
@@ -218,6 +218,6 @@ public class CpdReport extends AbstractPmdReport {
 
     @Override
     public String getOutputPath() {
-        return "pmd";
+        return "cpd";
     }
 }

--- a/src/main/java/org/apache/maven/plugins/pmd/PmdReport.java
+++ b/src/main/java/org/apache/maven/plugins/pmd/PmdReport.java
@@ -543,7 +543,13 @@ public class PmdReport extends AbstractPmdReport {
      * {@inheritDoc}
      */
     @Override
+    @Deprecated
     public String getOutputName() {
+        return "pmd";
+    }
+
+    @Override
+    public String getOutputPath() {
         return "pmd";
     }
 

--- a/src/test/java/org/apache/maven/plugins/pmd/AbstractPmdReportTestCase.java
+++ b/src/test/java/org/apache/maven/plugins/pmd/AbstractPmdReportTestCase.java
@@ -141,7 +141,7 @@ public abstract class AbstractPmdReportTestCase extends AbstractMojoTestCase {
         testMavenProject = builder.build(pluginXmlFile, buildingRequest).getProject();
 
         File outputDir = mojo.getReportOutputDirectory();
-        String filename = mojo.getOutputName() + ".html";
+        String filename = mojo.getOutputPath() + ".html";
 
         return new File(outputDir, filename);
     }

--- a/src/test/java/org/apache/maven/plugins/pmd/CpdReportTest.java
+++ b/src/test/java/org/apache/maven/plugins/pmd/CpdReportTest.java
@@ -182,7 +182,7 @@ public class CpdReportTest extends AbstractPmdReportTestCase {
     public void testEmptyReportConfiguration() throws Exception {
         // verify the generated files do exist, even if there are no violations
         File generatedReport = generateReport(getGoal(), "empty-report/cpd-empty-report-plugin-config.xml");
-        assertTrue(new File(generatedReport.getAbsolutePath()).exists());
+        assertTrue(generatedReport.getAbsolutePath() + " does not exist", new File(generatedReport.getAbsolutePath()).exists());
 
         String str = readFile(generatedReport);
         assertFalse(lowerCaseContains(str, "Hello.java"));

--- a/src/test/java/org/apache/maven/plugins/pmd/CpdReportTest.java
+++ b/src/test/java/org/apache/maven/plugins/pmd/CpdReportTest.java
@@ -182,7 +182,9 @@ public class CpdReportTest extends AbstractPmdReportTestCase {
     public void testEmptyReportConfiguration() throws Exception {
         // verify the generated files do exist, even if there are no violations
         File generatedReport = generateReport(getGoal(), "empty-report/cpd-empty-report-plugin-config.xml");
-        assertTrue(generatedReport.getAbsolutePath() + " does not exist", new File(generatedReport.getAbsolutePath()).exists());
+        assertTrue(
+                generatedReport.getAbsolutePath() + " does not exist",
+                new File(generatedReport.getAbsolutePath()).exists());
 
         String str = readFile(generatedReport);
         assertFalse(lowerCaseContains(str, "Hello.java"));


### PR DESCRIPTION
Implement getOutputPath and identify getOutputName as deprecated, as it already is in super-interface MavenReport