### PR TITLE
Get rid of maven-artifact-transfer and other legacy stuff

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,12 +116,6 @@ under the License.
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
-      <artifactId>maven-compat</artifactId>
-      <version>${mavenVersion}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>${mavenVersion}</version>
       <scope>provided</scope>
@@ -133,25 +127,9 @@ under the License.
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.maven.shared</groupId>
-      <artifactId>maven-artifact-transfer</artifactId>
-      <version>0.13.1</version>
-    </dependency>
-    <dependency>
       <groupId>org.eclipse.sisu</groupId>
       <artifactId>org.eclipse.sisu.plexus</artifactId>
       <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven.shared</groupId>
-      <artifactId>maven-common-artifact-filters</artifactId>
-      <version>3.4.0</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.sonatype.sisu</groupId>
-          <artifactId>sisu-inject-plexus</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
@@ -257,14 +235,8 @@ under the License.
     <dependency>
       <groupId>org.apache.maven.plugin-testing</groupId>
       <artifactId>maven-plugin-testing-harness</artifactId>
-      <version>3.3.0</version>
+      <version>4.0.0-alpha-2</version>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.codehaus.plexus</groupId>
-          <artifactId>plexus-container-default</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.github.tomakehurst</groupId>
@@ -282,7 +254,6 @@ under the License.
       <groupId>org.apache.maven.resolver</groupId>
       <artifactId>maven-resolver-api</artifactId>
       <version>${resolverVersion}</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.resolver</groupId>
@@ -298,14 +269,8 @@ under the License.
     </dependency>
     <dependency>
       <groupId>org.apache.maven.resolver</groupId>
-      <artifactId>maven-resolver-transport-wagon</artifactId>
+      <artifactId>maven-resolver-transport-http</artifactId>
       <version>${resolverVersion}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven.wagon</groupId>
-      <artifactId>wagon-http-lightweight</artifactId>
-      <version>3.5.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -430,6 +395,7 @@ under the License.
             <configuration>
               <localRepositoryPath>${project.build.directory}/local-repo</localRepositoryPath>
               <debug>false</debug>
+              <showErrors>true</showErrors>
               <goals>
                 <goal>clean</goal>
                 <goal>site</goal>

--- a/src/main/java/org/apache/maven/plugins/pmd/AggregatorPmdNoForkReport.java
+++ b/src/main/java/org/apache/maven/plugins/pmd/AggregatorPmdNoForkReport.java
@@ -25,7 +25,6 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.plugins.pmd.exec.PmdServiceExecutor;
-import org.apache.maven.shared.transfer.dependencies.resolve.DependencyResolver;
 import org.codehaus.plexus.i18n.I18N;
 import org.codehaus.plexus.resource.ResourceManager;
 
@@ -45,9 +44,9 @@ public class AggregatorPmdNoForkReport extends AggregatorPmdReport {
     @Inject
     public AggregatorPmdNoForkReport(
             ResourceManager locator,
-            DependencyResolver dependencyResolver,
+            ConfigurationService configurationService,
             I18N i18n,
             PmdServiceExecutor serviceExecutor) {
-        super(locator, dependencyResolver, i18n, serviceExecutor);
+        super(locator, configurationService, i18n, serviceExecutor);
     }
 }

--- a/src/main/java/org/apache/maven/plugins/pmd/AggregatorPmdReport.java
+++ b/src/main/java/org/apache/maven/plugins/pmd/AggregatorPmdReport.java
@@ -25,7 +25,6 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.plugins.pmd.exec.PmdServiceExecutor;
-import org.apache.maven.shared.transfer.dependencies.resolve.DependencyResolver;
 import org.codehaus.plexus.i18n.I18N;
 import org.codehaus.plexus.resource.ResourceManager;
 
@@ -42,10 +41,10 @@ public class AggregatorPmdReport extends PmdReport {
     @Inject
     public AggregatorPmdReport(
             ResourceManager locator,
-            DependencyResolver dependencyResolver,
+            ConfigurationService configurationService,
             I18N i18n,
             PmdServiceExecutor serviceExecutor) {
-        super(locator, dependencyResolver, i18n, serviceExecutor);
+        super(locator, configurationService, i18n, serviceExecutor);
     }
 
     @Override

--- a/src/main/java/org/apache/maven/plugins/pmd/ConfigurationService.java
+++ b/src/main/java/org/apache/maven/plugins/pmd/ConfigurationService.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugins.pmd;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.maven.RepositoryUtils;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.DependencyManagement;
+import org.apache.maven.project.MavenProject;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.ArtifactTypeRegistry;
+import org.eclipse.aether.collection.CollectRequest;
+import org.eclipse.aether.resolution.ArtifactResult;
+import org.eclipse.aether.resolution.DependencyRequest;
+import org.eclipse.aether.resolution.DependencyResolutionException;
+import org.eclipse.aether.resolution.DependencyResult;
+
+/**
+ * utils service for provide configuration needed to execute CPD/PMD.
+ */
+@Named
+@Singleton
+public class ConfigurationService {
+
+    private final Provider<MavenSession> sessionProvider;
+
+    private final org.eclipse.aether.RepositorySystem repositorySystem;
+
+    @Inject
+    public ConfigurationService(
+            Provider<MavenSession> sessionProvider, org.eclipse.aether.RepositorySystem repositorySystem) {
+        this.sessionProvider = sessionProvider;
+        this.repositorySystem = repositorySystem;
+    }
+
+    public List<File> resolveDependenciesAsFile(
+            MavenProject localProject, Collection<MavenProject> aggregatedProjects, boolean includeTests)
+            throws DependencyResolutionException {
+
+        RepositorySystemSession repositorySession = sessionProvider.get().getRepositorySession();
+        ArtifactTypeRegistry artifactTypeRegistry = repositorySession.getArtifactTypeRegistry();
+
+        List<String> includesScope =
+                includeTests ? Arrays.asList("compile", "provided", "test") : Arrays.asList("compile", "provided");
+
+        // collect exclusions for projects within the reactor
+        // if module a depends on module b and both are in the reactor
+        // then we don't want to resolve the dependency as an artifact.
+        List<String> exclusionPatterns = new ArrayList<>();
+        for (MavenProject project : aggregatedProjects) {
+            exclusionPatterns.add(getExclusionKey(project));
+        }
+
+        List<org.eclipse.aether.graph.Dependency> dependencies = localProject.getDependencies().stream()
+                .filter(dependency -> includesScope.contains(dependency.getScope()))
+                .filter(dependency -> !exclusionPatterns.contains(getExclusionKey(dependency)))
+                .map(d -> RepositoryUtils.toDependency(d, artifactTypeRegistry))
+                .collect(Collectors.toList());
+
+        List<org.eclipse.aether.graph.Dependency> dependencyManagements = Optional.ofNullable(
+                        localProject.getDependencyManagement())
+                .map(DependencyManagement::getDependencies)
+                .map(Collection::stream)
+                .orElse(Stream.empty())
+                .map(d -> RepositoryUtils.toDependency(d, artifactTypeRegistry))
+                .collect(Collectors.toList());
+
+        CollectRequest collectRequest =
+                new CollectRequest(dependencies, dependencyManagements, localProject.getRemoteProjectRepositories());
+        DependencyRequest request = new DependencyRequest(collectRequest, null);
+
+        DependencyResult result =
+                repositorySystem.resolveDependencies(sessionProvider.get().getRepositorySession(), request);
+
+        return result.getArtifactResults().stream()
+                .map(ArtifactResult::getArtifact)
+                .map(Artifact::getFile)
+                .collect(Collectors.toList());
+    }
+
+    private String getExclusionKey(Dependency dependency) {
+        return dependency.getGroupId() + ":" + dependency.getArtifactId();
+    }
+
+    private String getExclusionKey(MavenProject project) {
+        return project.getGroupId() + ":" + project.getArtifactId();
+    }
+}

--- a/src/test/java/org/apache/maven/plugins/pmd/AbstractPmdReportTestCase.java
+++ b/src/test/java/org/apache/maven/plugins/pmd/AbstractPmdReportTestCase.java
@@ -90,19 +90,17 @@ public abstract class AbstractPmdReportTestCase extends AbstractMojoTestCase {
         MavenSession mavenSession = newMavenSession(new MavenProjectStub());
         sessionScope.seed(MavenSession.class, mavenSession);
 
-        LegacySupport legacySupport = lookup(LegacySupport.class);
-        legacySupport.setSession(mavenSession);
-        DefaultRepositorySystemSession repoSession =
-                (DefaultRepositorySystemSession) legacySupport.getRepositorySession();
-        repoSession.setLocalRepositoryManager(new SimpleLocalRepositoryManagerFactory()
-                .newInstance(repoSession, new LocalRepository(artifactStubFactory.getWorkingDir())));
+        DefaultRepositorySystemSession repositorySession =
+                (DefaultRepositorySystemSession) mavenSession.getRepositorySession();
+        repositorySession.setLocalRepositoryManager(new SimpleLocalRepositoryManagerFactory()
+                .newInstance(repositorySession, new LocalRepository(artifactStubFactory.getWorkingDir())));
 
         List<MavenProject> reactorProjects =
                 mojo.getReactorProjects() != null ? mojo.getReactorProjects() : Collections.emptyList();
 
         setVariableValueToObject(mojo, "mojoExecution", getMockMojoExecution());
-        setVariableValueToObject(mojo, "session", legacySupport.getSession());
-        setVariableValueToObject(mojo, "repoSession", legacySupport.getRepositorySession());
+        setVariableValueToObject(mojo, "session", mavenSession);
+        setVariableValueToObject(mojo, "repoSession", repositorySession);
         setVariableValueToObject(mojo, "reactorProjects", reactorProjects);
         setVariableValueToObject(
                 mojo, "remoteProjectRepositories", mojo.getProject().getRemoteProjectRepositories());


### PR DESCRIPTION
- use resolver API for resolving dependencies

- introduce ConfigurationService as util where we will be able to move the methods needed for preparing configuration for PMDExecutor