### PR TITLE
Clean up some Javadoc comments

### DIFF
--- a/src/main/java/org/apache/maven/plugins/pmd/AbstractPmdReport.java
+++ b/src/main/java/org/apache/maven/plugins/pmd/AbstractPmdReport.java
@@ -273,11 +273,11 @@ public abstract class AbstractPmdReport extends AbstractMavenReport {
     }
 
     /**
-     * Convenience method to get the list of files where the PMD tool will be executed
+     * Convenience method to retrieve the files on which the PMD tool will be executed.
      *
-     * @return a List of the files where the PMD tool will be executed
-     * @throws IOException If an I/O error occurs during construction of the
-     *                     canonical pathnames of the files
+     * @return a map of the files where the PMD tool will be executed
+     * @throws IOException if an I/O error occurs during construction of the
+     *                     canonical paths of the files
      */
     protected Map<File, PmdFileInfo> getFilesToProcess() throws IOException {
         if (aggregate && !project.isExecutionRoot()) {
@@ -481,7 +481,6 @@ public abstract class AbstractPmdReport extends AbstractMavenReport {
      *
      * @param aggregatedProject the project being aggregated
      * @param reactorProjectsMap map of (still) available reactor projects
-     * @throws MavenReportException if any
      */
     private Set<MavenProject> modulesForAggregatedProject(
             MavenProject aggregatedProject, Map<Path, MavenProject> reactorProjectsMap) {

--- a/src/main/java/org/apache/maven/plugins/pmd/AbstractPmdViolationCheckMojo.java
+++ b/src/main/java/org/apache/maven/plugins/pmd/AbstractPmdViolationCheckMojo.java
@@ -175,11 +175,7 @@ public abstract class AbstractPmdViolationCheckMojo<D> extends AbstractMojo {
     /**
      * Method for collecting the violations found by the PMD tool
      *
-     * @param analysisFile
-     * @param failurePriority
      * @return an int that specifies the number of violations found
-     * @throws XmlPullParserException
-     * @throws IOException
      */
     private ViolationDetails<D> getViolations(final File analysisFile, final int failurePriority)
             throws XmlPullParserException, IOException {
@@ -227,14 +223,7 @@ public abstract class AbstractPmdViolationCheckMojo<D> extends AbstractMojo {
     }
 
     /**
-     * Gets the output message
-     *
-     * @param failureCount
-     * @param warningCount
-     * @param analyzerName
-     * @param failureName
-     * @param outputFile
-     * @return
+     * Gets the output message.
      */
     private String getMessage(
             final int failureCount,

--- a/src/main/java/org/apache/maven/plugins/pmd/exec/PmdExecutor.java
+++ b/src/main/java/org/apache/maven/plugins/pmd/exec/PmdExecutor.java
@@ -352,9 +352,6 @@ public class PmdExecutor extends Executor {
 
     /**
      * Use the PMD renderers to render in any format aside from HTML and XML.
-     *
-     * @param report
-     * @throws MavenReportException
      */
     private void writeFormattedReport(Report report) throws IOException, MavenReportException {
         Renderer renderer = createRenderer(request.getFormat(), request.getOutputEncoding());


### PR DESCRIPTION
Mostly removes IDE generated boilerplate that only occupies vertical screen space