### PR TITLE
Simplify stub setup by not swallowing exceptions

### DIFF
--- a/src/test/java/org/apache/maven/plugins/pmd/stubs/CustomConfigurationMavenProjectStub.java
+++ b/src/test/java/org/apache/maven/plugins/pmd/stubs/CustomConfigurationMavenProjectStub.java
@@ -20,6 +20,7 @@ package org.apache.maven.plugins.pmd.stubs;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
@@ -28,8 +29,8 @@ import org.apache.maven.artifact.Artifact;
 import org.apache.maven.model.Build;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.ReportPlugin;
-import org.apache.maven.model.Scm;
 import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
+import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 
 /**
  * @author <a href="mailto:oching@apache.org">Maria Odea Ching</a>
@@ -40,34 +41,26 @@ public class CustomConfigurationMavenProjectStub extends PmdProjectStub {
 
     private List<ReportPlugin> reportPlugins = new ArrayList<>();
 
-    public CustomConfigurationMavenProjectStub() {
+    public CustomConfigurationMavenProjectStub() throws IOException, XmlPullParserException {
         MavenXpp3Reader pomReader = new MavenXpp3Reader();
-        Model model = null;
 
-        try (InputStream is = new FileInputStream(new File(getBasedir() + "/" + getPOM()))) {
-            model = pomReader.read(is);
+        try (InputStream in = new FileInputStream(getBasedir() + "/" + getPOM())) {
+            Model model = pomReader.read(in);
             setModel(model);
-        } catch (Exception e) {
+
+            setGroupId(model.getGroupId());
+            setArtifactId(model.getArtifactId());
+            setVersion(model.getVersion());
+            setName(model.getName());
+            setUrl(model.getUrl());
+            setPackaging(model.getPackaging());
+            setReportPlugins(model.getReporting().getPlugins());
+            Build build = new Build();
+            build.setFinalName(model.getBuild().getFinalName());
+            build.setDirectory(getBasedir() + "/target");
+            build.setSourceDirectory(getBasedir().getAbsolutePath());
+            setBuild(build);
         }
-
-        setGroupId(model.getGroupId());
-        setArtifactId(model.getArtifactId());
-        setVersion(model.getVersion());
-        setName(model.getName());
-        setUrl(model.getUrl());
-        setPackaging(model.getPackaging());
-
-        Scm scm = new Scm();
-        scm.setConnection("scm:svn:http://svn.apache.org/maven/sample/trunk");
-        setScm(scm);
-
-        Build build = new Build();
-        build.setFinalName(model.getBuild().getFinalName());
-        build.setDirectory(getBasedir() + "/target");
-        build.setSourceDirectory(getBasedir().getAbsolutePath());
-        setBuild(build);
-
-        setReportPlugins(model.getReporting().getPlugins());
 
         String basedir = getBasedir().getAbsolutePath();
         List<String> compileSourceRoots = new ArrayList<>();

--- a/src/test/java/org/apache/maven/plugins/pmd/stubs/DefaultConfigurationMavenProjectStub.java
+++ b/src/test/java/org/apache/maven/plugins/pmd/stubs/DefaultConfigurationMavenProjectStub.java
@@ -20,6 +20,7 @@ package org.apache.maven.plugins.pmd.stubs;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
@@ -28,8 +29,8 @@ import org.apache.maven.artifact.Artifact;
 import org.apache.maven.model.Build;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.ReportPlugin;
-import org.apache.maven.model.Scm;
 import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
+import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 
 /**
  * @author <a href="mailto:oching@apache.org">Maria Odea Ching</a>
@@ -40,34 +41,26 @@ public class DefaultConfigurationMavenProjectStub extends PmdProjectStub {
 
     private Build build;
 
-    public DefaultConfigurationMavenProjectStub() {
+    public DefaultConfigurationMavenProjectStub() throws XmlPullParserException, IOException {
         MavenXpp3Reader pomReader = new MavenXpp3Reader();
-        Model model = null;
 
         try (InputStream is = new FileInputStream(new File(getBasedir() + "/" + getPOM()))) {
-            model = pomReader.read(is);
-            setModel(model);
-        } catch (Exception e) {
+            Model model = pomReader.read(is);
+
+            setGroupId(model.getGroupId());
+            setArtifactId(model.getArtifactId());
+            setVersion(model.getVersion());
+            setName(model.getName());
+            setUrl(model.getUrl());
+            setPackaging(model.getPackaging());
+            setReportPlugins(model.getReporting().getPlugins());
+
+            Build build = new Build();
+            build.setFinalName(model.getBuild().getFinalName());
+            build.setDirectory(getBasedir() + "/target");
+            build.setSourceDirectory(getBasedir().getAbsolutePath());
+            setBuild(build);
         }
-
-        setGroupId(model.getGroupId());
-        setArtifactId(model.getArtifactId());
-        setVersion(model.getVersion());
-        setName(model.getName());
-        setUrl(model.getUrl());
-        setPackaging(model.getPackaging());
-
-        Scm scm = new Scm();
-        scm.setConnection("scm:svn:http://svn.apache.org/maven/sample/trunk");
-        setScm(scm);
-
-        Build build = new Build();
-        build.setFinalName(model.getBuild().getFinalName());
-        build.setDirectory(getBasedir() + "/target");
-        build.setSourceDirectory(getBasedir().getAbsolutePath());
-        setBuild(build);
-
-        setReportPlugins(model.getReporting().getPlugins());
 
         String basedir = getBasedir().getAbsolutePath();
         List<String> compileSourceRoots = new ArrayList<>();

--- a/src/test/java/org/apache/maven/plugins/pmd/stubs/InvalidFormatMavenProjectStub.java
+++ b/src/test/java/org/apache/maven/plugins/pmd/stubs/InvalidFormatMavenProjectStub.java
@@ -20,6 +20,7 @@ package org.apache.maven.plugins.pmd.stubs;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
@@ -27,8 +28,8 @@ import java.util.List;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.model.Build;
 import org.apache.maven.model.Model;
-import org.apache.maven.model.Scm;
 import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
+import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 
 /**
  * @author <a href="mailto:oching@apache.org">Maria Odea Ching</a>
@@ -37,32 +38,25 @@ import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
 public class InvalidFormatMavenProjectStub extends PmdProjectStub {
     private Build build;
 
-    public InvalidFormatMavenProjectStub() {
+    public InvalidFormatMavenProjectStub() throws XmlPullParserException, IOException {
         MavenXpp3Reader pomReader = new MavenXpp3Reader();
-        Model model = null;
 
-        try (InputStream is = new FileInputStream(new File(getBasedir() + "/" + getPOM()))) {
-            model = pomReader.read(is);
+        try (InputStream is = new FileInputStream(getBasedir() + "/" + getPOM())) {
+            Model model = pomReader.read(is);
             setModel(model);
-        } catch (Exception e) {
+            setGroupId(model.getGroupId());
+            setArtifactId(model.getArtifactId());
+            setVersion(model.getVersion());
+            setName(model.getName());
+            setUrl(model.getUrl());
+            setPackaging(model.getPackaging());
+
+            Build build = new Build();
+            build.setFinalName(model.getBuild().getFinalName());
+            build.setDirectory(getBasedir() + "/target");
+            build.setSourceDirectory(getBasedir().getAbsolutePath());
+            setBuild(build);
         }
-
-        setGroupId(model.getGroupId());
-        setArtifactId(model.getArtifactId());
-        setVersion(model.getVersion());
-        setName(model.getName());
-        setUrl(model.getUrl());
-        setPackaging(model.getPackaging());
-
-        Scm scm = new Scm();
-        scm.setConnection("scm:svn:http://svn.apache.org/maven/sample/trunk");
-        setScm(scm);
-
-        Build build = new Build();
-        build.setFinalName(model.getBuild().getFinalName());
-        build.setDirectory(getBasedir() + "/target");
-        build.setSourceDirectory(getBasedir().getAbsolutePath());
-        setBuild(build);
 
         String basedir = getBasedir().getAbsolutePath();
         List<String> compileSourceRoots = new ArrayList<>();


### PR DESCRIPTION
and removing Scm objects that were thrown  away by the setter not setting anything.