### PR TITLE
Use maven-embedder in test scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@ under the License.
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-embedder</artifactId>
       <version>${mavenVersion}</version>
-      <scope>provided</scope>
+      <scope>test</scope>
     </dependency>
 
     <!-- pmd -->

--- a/src/test/java/org/apache/maven/plugins/pmd/AbstractPmdReportTestCase.java
+++ b/src/test/java/org/apache/maven/plugins/pmd/AbstractPmdReportTestCase.java
@@ -83,7 +83,7 @@ public abstract class AbstractPmdReportTestCase extends AbstractMojoTestCase {
     }
 
     protected AbstractPmdReport createReportMojo(String goal, File pluginXmlFile) throws Exception {
-        AbstractPmdReport mojo = (AbstractPmdReport) lookupMojo(goal, pluginXmlFile);
+        AbstractPmdReport mojo = lookupMojo(goal, pluginXmlFile);
         assertNotNull("Mojo not found.", mojo);
 
         SessionScope sessionScope = lookup(SessionScope.class);

--- a/src/test/java/org/apache/maven/plugins/pmd/CpdReportTest.java
+++ b/src/test/java/org/apache/maven/plugins/pmd/CpdReportTest.java
@@ -22,6 +22,11 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -151,6 +156,7 @@ public class CpdReportTest extends AbstractPmdReportTestCase {
 
     /**
      * verify the cpd.xml file is included in the reports when requested.
+     *
      * @throws Exception
      */
     public void testIncludeXmlInReports() throws Exception {
@@ -247,8 +253,8 @@ public class CpdReportTest extends AbstractPmdReportTestCase {
             fail("MojoExecutionException must be thrown");
         } catch (MojoExecutionException e) {
             assertMavenReportException("There was 1 error while executing CPD", e);
-            assertLogOutputContains("Lexical error in file");
-            assertLogOutputContains("BadFile.java");
+            assertReportContains("Lexical error in file");
+            assertReportContains("BadFile.java");
         }
     }
 
@@ -262,9 +268,12 @@ public class CpdReportTest extends AbstractPmdReportTestCase {
                 exception.toString().contains(expectedMessage));
     }
 
-    private static void assertLogOutputContains(String expectedMessage) {
-        String log = CapturingPrintStream.getOutput();
-        assertTrue("Expected '" + expectedMessage + "' in log, but was:\n" + log, log.contains(expectedMessage));
+    private static void assertReportContains(String expectedMessage) throws IOException {
+        Path path = Paths.get(getBasedir(), "target/test/unit/CpdReportTest/with-cpd-errors/target/cpd.xml");
+        String report = new String(Files.readAllBytes(path), StandardCharsets.UTF_8);
+
+        assertTrue(
+                "Expected '" + expectedMessage + "' in cpd.xml, but was:\n" + report, report.contains(expectedMessage));
     }
 
     @Override

--- a/src/test/java/org/apache/maven/plugins/pmd/CpdViolationCheckMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/pmd/CpdViolationCheckMojoTest.java
@@ -36,7 +36,7 @@ public class CpdViolationCheckMojoTest extends AbstractPmdReportTestCase {
             File testPom = new File(
                     getBasedir(),
                     "src/test/resources/unit/default-configuration/cpd-check-default-configuration-plugin-config.xml");
-            CpdViolationCheckMojo cpdViolationCheckMojo = (CpdViolationCheckMojo) lookupMojo(getGoal(), testPom);
+            CpdViolationCheckMojo cpdViolationCheckMojo = lookupMojo(getGoal(), testPom);
             cpdViolationCheckMojo.execute();
 
             fail("MojoFailureException should be thrown.");
@@ -51,7 +51,7 @@ public class CpdViolationCheckMojoTest extends AbstractPmdReportTestCase {
         File testPom = new File(
                 getBasedir(),
                 "src/test/resources/unit/default-configuration/cpd-check-notfailonviolation-plugin-config.xml");
-        CpdViolationCheckMojo cpdViolationCheckMojo = (CpdViolationCheckMojo) lookupMojo(getGoal(), testPom);
+        CpdViolationCheckMojo cpdViolationCheckMojo = lookupMojo(getGoal(), testPom);
         cpdViolationCheckMojo.execute();
     }
 
@@ -60,7 +60,7 @@ public class CpdViolationCheckMojoTest extends AbstractPmdReportTestCase {
             File testPom = new File(
                     getBasedir(),
                     "src/test/resources/unit/custom-configuration/cpd-check-exception-test-plugin-config.xml");
-            CpdViolationCheckMojo cpdViolationCheckMojo = (CpdViolationCheckMojo) lookupMojo(getGoal(), testPom);
+            CpdViolationCheckMojo cpdViolationCheckMojo = lookupMojo(getGoal(), testPom);
             cpdViolationCheckMojo.project = new MavenProject();
             cpdViolationCheckMojo.execute();
 
@@ -76,7 +76,7 @@ public class CpdViolationCheckMojoTest extends AbstractPmdReportTestCase {
         File testPom = new File(
                 getBasedir(),
                 "src/test/resources/unit/default-configuration/cpd-check-cpd-exclusions-configuration-plugin-config.xml");
-        CpdViolationCheckMojo cpdViolationCheckMojo = (CpdViolationCheckMojo) lookupMojo(getGoal(), testPom);
+        CpdViolationCheckMojo cpdViolationCheckMojo = lookupMojo(getGoal(), testPom);
 
         // this call shouldn't throw an exception, as the classes with duplications have been excluded
         cpdViolationCheckMojo.execute();

--- a/src/test/java/org/apache/maven/plugins/pmd/PmdViolationCheckMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/pmd/PmdViolationCheckMojoTest.java
@@ -32,14 +32,11 @@ public class PmdViolationCheckMojoTest extends AbstractPmdReportTestCase {
     public void testDefaultConfiguration() throws Exception {
         generateReport("pmd", "default-configuration/default-configuration-plugin-config.xml");
 
-        // clear the output from previous pmd:pmd execution
-        CapturingPrintStream.init(true);
-
         try {
             final File testPom = new File(
                     getBasedir(),
                     "src/test/resources/unit/default-configuration/pmd-check-default-configuration-plugin-config.xml");
-            final PmdViolationCheckMojo mojo = (PmdViolationCheckMojo) lookupMojo(getGoal(), testPom);
+            final PmdViolationCheckMojo mojo = lookupMojo(getGoal(), testPom);
             mojo.execute();
 
             fail("MojoFailureException should be thrown.");
@@ -55,7 +52,7 @@ public class PmdViolationCheckMojoTest extends AbstractPmdReportTestCase {
         File testPom = new File(
                 getBasedir(),
                 "src/test/resources/unit/default-configuration/pmd-check-notfailonviolation-plugin-config.xml");
-        final PmdViolationCheckMojo pmdViolationMojo = (PmdViolationCheckMojo) lookupMojo(getGoal(), testPom);
+        final PmdViolationCheckMojo pmdViolationMojo = lookupMojo(getGoal(), testPom);
         pmdViolationMojo.execute();
     }
 
@@ -65,13 +62,13 @@ public class PmdViolationCheckMojoTest extends AbstractPmdReportTestCase {
         File testPom = new File(
                 getBasedir(),
                 "src/test/resources/unit/default-configuration/pmd-check-notfailmaxviolation-plugin-config.xml");
-        final PmdViolationCheckMojo pmdViolationMojo = (PmdViolationCheckMojo) lookupMojo(getGoal(), testPom);
+        final PmdViolationCheckMojo pmdViolationMojo = lookupMojo(getGoal(), testPom);
         pmdViolationMojo.execute();
 
         testPom = new File(
                 getBasedir(),
                 "src/test/resources/unit/default-configuration/pmd-check-failmaxviolation-plugin-config.xml");
-        final PmdViolationCheckMojo pmdViolationMojoFail = (PmdViolationCheckMojo) lookupMojo(getGoal(), testPom);
+        final PmdViolationCheckMojo pmdViolationMojoFail = lookupMojo(getGoal(), testPom);
 
         try {
             pmdViolationMojoFail.execute();
@@ -89,13 +86,13 @@ public class PmdViolationCheckMojoTest extends AbstractPmdReportTestCase {
         File testPom = new File(
                 getBasedir(),
                 "src/test/resources/unit/default-configuration/pmd-check-failonpriority-plugin-config.xml");
-        PmdViolationCheckMojo pmdViolationCheckMojo = (PmdViolationCheckMojo) lookupMojo(getGoal(), testPom);
+        PmdViolationCheckMojo pmdViolationCheckMojo = lookupMojo(getGoal(), testPom);
         pmdViolationCheckMojo.execute();
 
         testPom = new File(
                 getBasedir(),
                 "src/test/resources/unit/default-configuration/pmd-check-failandwarnonpriority-plugin-config.xml");
-        pmdViolationCheckMojo = (PmdViolationCheckMojo) lookupMojo(getGoal(), testPom);
+        pmdViolationCheckMojo = lookupMojo(getGoal(), testPom);
 
         try {
             pmdViolationCheckMojo.execute();
@@ -112,7 +109,7 @@ public class PmdViolationCheckMojoTest extends AbstractPmdReportTestCase {
             final File testPom = new File(
                     getBasedir(),
                     "src/test/resources/unit/custom-configuration/pmd-check-exception-test-plugin-config.xml");
-            final PmdViolationCheckMojo mojo = (PmdViolationCheckMojo) lookupMojo(getGoal(), testPom);
+            final PmdViolationCheckMojo mojo = lookupMojo(getGoal(), testPom);
             mojo.project = new MavenProject();
             mojo.execute();
 
@@ -128,7 +125,7 @@ public class PmdViolationCheckMojoTest extends AbstractPmdReportTestCase {
         File testPom = new File(
                 getBasedir(),
                 "src/test/resources/unit/default-configuration/pmd-check-pmd-exclusions-configuration-plugin-config.xml");
-        final PmdViolationCheckMojo pmdViolationMojo = (PmdViolationCheckMojo) lookupMojo(getGoal(), testPom);
+        final PmdViolationCheckMojo pmdViolationMojo = lookupMojo(getGoal(), testPom);
 
         // this call shouldn't throw an exception, as the classes with violations have been excluded
         pmdViolationMojo.execute();


### PR DESCRIPTION
- maven-embedder is only used in tests.
- simple code cleanups, prepare to remove maven-embedder completely

