### PR TITLE
Use constant 3.6.3 in prerequisites/maven as minimal Maven version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@ under the License.
   </contributors>
 
   <prerequisites>
-    <maven>${mavenVersion}</maven>
+    <maven>3.6.3</maven>
   </prerequisites>
 
   <scm>


### PR DESCRIPTION
It will allow declaring a newer version of Maven dependencies in the project.
