### PR TITLE
Restore the document metadata dropped when the pages were ported

### DIFF
--- a/src/site/markdown/examples/aggregate.md.vm
+++ b/src/site/markdown/examples/aggregate.md.vm
@@ -1,3 +1,10 @@
+---
+title: Aggregating PMD reports for Multi-Module-Projects
+author: 
+  - Andreas Dangel
+date: 2021-09-03
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/examples/cpdCsharp.md.vm
+++ b/src/site/markdown/examples/cpdCsharp.md.vm
@@ -1,3 +1,10 @@
+---
+title: Finding duplicated code in C#
+author: 
+  - Andreas Dangel
+date: 2020-10-02
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/examples/differentRulesetForTests.md.vm
+++ b/src/site/markdown/examples/differentRulesetForTests.md.vm
@@ -1,3 +1,10 @@
+---
+title: Using a different ruleset for tests
+author: 
+  - Andreas Dangel
+date: 2021-07-09
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/examples/javascriptReport.md.vm
+++ b/src/site/markdown/examples/javascriptReport.md.vm
@@ -1,3 +1,10 @@
+---
+title: Analyzing JavaScript Code
+author: 
+  - Andreas Dangel
+date: 2017-11-11
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/examples/jspReport.md.vm
+++ b/src/site/markdown/examples/jspReport.md.vm
@@ -1,3 +1,10 @@
+---
+title: Analyzing JSP Code
+author: 
+  - Thomas Williamson
+date: 2017-11-11
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/examples/multi-module-config.md.vm
+++ b/src/site/markdown/examples/multi-module-config.md.vm
@@ -1,3 +1,8 @@
+---
+title: Multimodule Configuration
+date: 2017-11-11
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/examples/removeReport.md.vm
+++ b/src/site/markdown/examples/removeReport.md.vm
@@ -1,3 +1,10 @@
+---
+title: Remove Report
+author: 
+  - Dennis Lundberg
+date: 2021-09-03
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/examples/targetJdk.md.vm
+++ b/src/site/markdown/examples/targetJdk.md.vm
@@ -1,3 +1,11 @@
+---
+title: Target JDK and Toolchains
+author: 
+  - Dennis Lundberg
+  - Andreas Dangel
+date: 2020-10-02
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/examples/upgrading-PMD-at-runtime.md.vm
+++ b/src/site/markdown/examples/upgrading-PMD-at-runtime.md.vm
@@ -1,3 +1,10 @@
+---
+title: Upgrading PMD at Runtime
+author: 
+  - Andreas Dangel
+date: 2017-08-19
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/examples/usingRuleSets.md.vm
+++ b/src/site/markdown/examples/usingRuleSets.md.vm
@@ -1,3 +1,10 @@
+---
+title: Using Rule Sets
+author: 
+  - Maria Odea Ching
+date: 2018-01-10
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/examples/violation-exclusions.md.vm
+++ b/src/site/markdown/examples/violation-exclusions.md.vm
@@ -1,3 +1,9 @@
+---
+title: Violation Exclusions
+author: 
+  - 2013-02-08
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/examples/violationChecking.md.vm
+++ b/src/site/markdown/examples/violationChecking.md.vm
@@ -1,3 +1,9 @@
+---
+title: Violation Checking
+author: 
+  - 2006-06-23
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/index.md.vm
+++ b/src/site/markdown/index.md.vm
@@ -1,3 +1,10 @@
+---
+title: Introduction
+author: 
+  - Dennis Lundberg
+date: 2017-11-11
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/usage.md.vm
+++ b/src/site/markdown/usage.md.vm
@@ -1,3 +1,10 @@
+---
+title: Usage
+author: 
+  - Maria Odea Ching
+date: 2017-11-11
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file


### PR DESCRIPTION
The site pages lost their document metadata when they were ported from APT.

An APT document opens with a header block giving its title, authors and date, and
`doxia-converter` turns that into YAML front matter. The port dropped the front matter
along with the converter's per-line licence comments, so the generated pages lost their
`<meta name="author">` and date, and took their `<title>` from the first heading instead
of from the document title.

Building one project's site from the APT sources and from the ported Markdown shows the
difference:

| | `<title>` produced |
|---|---|
| APT original | `Release Notes - Modello` |
| ported Markdown | `Modello - Modello` |
| with this change | `Release Notes - Modello` |

The front matter has to come first in the file, because the Markdown parser only looks
for it when the source begins with `---`; a licence header ahead of it would hide it.
RAT is happy either way.

Verified by building the site before and after and comparing `<title>` and the author
meta tags of every generated page, and by confirming the front matter does not reach
the rendered body.