### PR TITLE
Drop backslash escapes that Markdown does not need

### DIFF
--- a/src/site/markdown/examples/usingRuleSets.md.vm
+++ b/src/site/markdown/examples/usingRuleSets.md.vm
@@ -65,7 +65,7 @@ See [Making Rulesets](https://pmd.github.io/pmd-${pmdVersion}/pmd_userdocs_makin
 
 This is an excerpt of the ruleset `/rulesets/java/maven-pmd-plugin-default.xml`. It contains only rules for Java. If you use a different language, you'll need to specify your own custom ruleset.
 
-The current version of the ruleset can be found in version control: [https://gitbox.apache.org/repos/asf?p=maven-pmd-plugin.git;a=blob\_plain;f=src/main/resources/rulesets/java/maven-pmd-plugin-default.xml;hb=HEAD](https://gitbox.apache.org/repos/asf?p=maven-pmd-plugin.git;a=blob_plain;f=src/main/resources/rulesets/java/maven-pmd-plugin-default.xml;hb=HEAD)
+The current version of the ruleset can be found in version control: [https://gitbox.apache.org/repos/asf?p=maven-pmd-plugin.git;a=blob_plain;f=src/main/resources/rulesets/java/maven-pmd-plugin-default.xml;hb=HEAD](https://gitbox.apache.org/repos/asf?p=maven-pmd-plugin.git;a=blob_plain;f=src/main/resources/rulesets/java/maven-pmd-plugin-default.xml;hb=HEAD)
 
 ```xml
     <rule ref="category/java/bestpractices.xml/AvoidUsingHardCodedIP" />


### PR DESCRIPTION
Pages converted from APT with an older `doxia-converter` carry a backslash in front of
punctuation that is not markup where it stands, for example `maven\-source\-plugin`,
`\(default\)` and `required\.`. The backslash renders as nothing; it only makes the source
harder to read and to edit, which was the point of moving to Markdown.

Only positions where the bare character can never be markup are touched: a hyphen,
underscore or asterisk between two word characters, a parenthesis, a full stop that
does not follow a digit, and an exclamation mark not followed by `[`.

Left alone deliberately:

* angle brackets, since `<escapeString>` really would be read as an HTML tag
* a full stop after a digit, so an ordered list marker cannot appear by accident
* a run of dots, because bare `...` is rendered as a single ellipsis character
* code spans, fenced blocks and link destinations

Verified by building the site before and after: every generated page is identical in
its visible text and in every link target.