### PR TITLE
Keep the FAQ quotation marks straight

### DIFF
--- a/src/site/markdown/faq.md
+++ b/src/site/markdown/faq.md
@@ -68,10 +68,10 @@ ruleset (see property [rulesets](pmd-mojo.html#rulesets)). Each rule has a assig
 2 - medium-high, 3 - medium, 4 - medium-low, 5 - low). This priority is also used for the violation.
 
 Violations with a high enough priority can fail the build when using the [check](check-mojo.html) goal. These
-violations are called "failures". The exact priority, when to fail the build, is configured via the property
+violations are called &quot;failures&quot;. The exact priority, when to fail the build, is configured via the property
 [failurePriority](check-mojo.html#failurePriority).
 
-Violations, that have a priority too low to fail the build, are called "warnings". These warnings appear in
+Violations, that have a priority too low to fail the build, are called &quot;warnings&quot;. These warnings appear in
 the report and are displayed in the build output, if the property [verbose](check-mojo.html#verbose) is
 enabled.
 
@@ -95,7 +95,7 @@ for type resolution, but also the project's classes as well.
 When using the property [aggregate](pmd-mojo.html#aggregate), this is problematic: With aggregate=true, PMD is
 executed at the root of a multi-module project *before the individual modules are built*. Then the types of
 the individual projects are not available, which might lead to false positive findings e.g. for the rule
-"UnusedPrivateMethod". That's why this property has been deprecated.
+&quot;UnusedPrivateMethod&quot;. That's why this property has been deprecated.
 
 In order to use type resolution and aggregate together, maven needs to be execute in two passes: First pass
 will compile the projects (e.g. `mvn clean package`) and the second pass will execute PMD without clean via


### PR DESCRIPTION
Follow-up to #722, which converted this FAQ from FML to Markdown.

FML is XML, so it rendered quotation marks exactly as written. Markdown goes through flexmark, whose smart-punctuation extension rewrites a bare `"` into a typographic pair - so the converted page silently changed the visible text:

Three pairs: `"failures"`, `"warnings"` and `"UnusedPrivateMethod"`.

The last is a PMD rule name a reader may copy into a ruleset, where a curly quote is actively unhelpful.

Writing `&quot;` in the Markdown source keeps them straight. That is the convention the already-converted pages in `maven-site-plugin` use.

**Verified** by rebuilding and comparing against the original FML rendering: the quotation marks match again, no anchor changed, and the page is otherwise identical.

<sub>Drafted with Claude - please verify</sub>
